### PR TITLE
New sample: Customer Churn Risk Narrative

### DIFF
--- a/prompts/ai-builder/customer-churn-risk-narrative/README.md
+++ b/prompts/ai-builder/customer-churn-risk-narrative/README.md
@@ -1,0 +1,43 @@
+# Customer Churn Risk Narrative
+
+## Description
+
+This prompt takes six quantitative customer signals (login recency, support ticket volume and sentiment, renewal date, usage trend, NPS) and transforms them into a plain-English churn risk narrative with a risk level, a 2–3 sentence explanation, and three concrete actions ordered by urgency — all formatted for a non-technical account manager.
+
+This combines two patterns: **chain-of-thought reasoning** (five explicit internal steps before output) and **multi-signal synthesis** (converting raw metrics into a human-readable story). It bridges the gap between a predictive model that outputs a score and a person who needs to know *what to do next*.
+
+The direct business ROI is retention: catching a "Critical" or "High" risk account a week earlier can prevent churn that costs many times the cost of an intervention.
+
+## Prompt
+
+> You are a customer success analyst. Based on [last_login_date], [ticket_count], [ticket_sentiment], [renewal_date], [usage_trend], [nps_score], and [account_tier], think step by step to assess each signal, determine overall churn risk (Critical/High/Medium/Low), write a plain-English narrative, and recommend 3 concrete actions ordered by urgency.
+
+### Supported Language(s)
+
+- [English - US](./en-us/prompt.md)
+
+## Authors
+
+Solution|Author(s)
+--------|---------
+Customer Churn Risk Narrative | [OwnOptic](https://github.com/OwnOptic) ([@OwnOptic](https://twitter.com/OwnOptic))
+
+## Minimal Path to Awesome
+
+1. Navigate to [AI Builder](https://make.powerapps.com/) and select **AI Builder** > **Explore**
+2. Choose **Prompt** and click **Build your own prompt**
+3. Copy the content from [prompt.md](./en-us/prompt.md) and paste it into the prompt editor
+4. Add the following inputs of type **Text**: `last_login_date`, `ticket_count`, `ticket_sentiment`, `renewal_date`, `usage_trend`, `nps_score`, `account_tier`
+5. Save and publish the prompt
+6. Integrate with Power Automate on a weekly scheduled flow:
+   - Query Dataverse (or Dynamics 365) for all active accounts
+   - For each account, pass the signals to this AI Builder prompt
+   - Parse the output and update a `Churn Risk` column in Dataverse
+   - For accounts where risk is "Critical" or "High", send a Teams notification to the responsible account manager with the narrative and recommended actions
+7. Optionally surface the output in a Power Apps dashboard for the CS team
+
+## Disclaimer
+
+**THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**
+
+<img src="https://m365-visitor-stats.azurewebsites.net/powerplatform-prompts/samples/ai-builder/customer-churn-risk-narrative" aria-hidden="true" />

--- a/prompts/ai-builder/customer-churn-risk-narrative/assets/sample.json
+++ b/prompts/ai-builder/customer-churn-risk-narrative/assets/sample.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/pnp/samples/v1.0/metadata-schema.json",
+  "name": "pnp-powerplatform-prompts-customer-churn-risk-narrative",
+  "version": "1.0.0.0",
+  "title": "Customer Churn Risk Narrative",
+  "shortDescription": "Converts six customer health signals into a plain-English churn risk narrative with risk level, explanation, and 3 urgency-ordered recommended actions for account managers.",
+  "longDescription": "Uses chain-of-thought reasoning and multi-signal synthesis to assess login recency, support ticket volume/sentiment, renewal proximity, usage trend, NPS, and account tier. Outputs a churn risk level (Critical/High/Medium/Low), a 2–3 sentence narrative explaining the risk, three concrete actions for the account manager ordered by urgency, and a per-signal status table. Designed for weekly Power Automate batch processing of Dataverse/Dynamics 365 accounts.",
+  "url": "https://github.com/pnp/powerplatform-prompts/tree/main/prompts/ai-builder/customer-churn-risk-narrative",
+  "products": [
+    "AI Builder",
+    "Power Platform",
+    "Power Automate",
+    "Dataverse"
+  ],
+  "tags": [
+    "CUSTOMER SUCCESS",
+    "CHURN",
+    "RETENTION",
+    "CHAIN-OF-THOUGHT",
+    "MULTI-SIGNAL",
+    "CRM"
+  ],
+  "categories": [
+    "AI Builder"
+  ],
+  "metadata": [
+    {
+      "key": "prompt",
+      "value": "Based on customer signals [last_login_date], [ticket_count], [ticket_sentiment], [renewal_date], [usage_trend], [nps_score], [account_tier] — assess churn risk and recommend 3 actions."
+    }
+  ],
+  "thumbnails": [],
+  "authors": [
+    {
+      "gitHubAccount": "OwnOptic",
+      "name": "OwnOptic",
+      "pictureUrl": "https://github.com/OwnOptic.png"
+    }
+  ],
+  "creationDateTime": "2026-03-02T00:00:00Z",
+  "updateDateTime": "2026-03-02T00:00:00Z"
+}

--- a/prompts/ai-builder/customer-churn-risk-narrative/assets/sample.json
+++ b/prompts/ai-builder/customer-churn-risk-narrative/assets/sample.json
@@ -1,42 +1,54 @@
-{
-  "$schema": "https://developer.microsoft.com/en-us/json-schemas/pnp/samples/v1.0/metadata-schema.json",
-  "name": "pnp-powerplatform-prompts-customer-churn-risk-narrative",
-  "version": "1.0.0.0",
-  "title": "Customer Churn Risk Narrative",
-  "shortDescription": "Converts six customer health signals into a plain-English churn risk narrative with risk level, explanation, and 3 urgency-ordered recommended actions for account managers.",
-  "longDescription": "Uses chain-of-thought reasoning and multi-signal synthesis to assess login recency, support ticket volume/sentiment, renewal proximity, usage trend, NPS, and account tier. Outputs a churn risk level (Critical/High/Medium/Low), a 2–3 sentence narrative explaining the risk, three concrete actions for the account manager ordered by urgency, and a per-signal status table. Designed for weekly Power Automate batch processing of Dataverse/Dynamics 365 accounts.",
-  "url": "https://github.com/pnp/powerplatform-prompts/tree/main/prompts/ai-builder/customer-churn-risk-narrative",
-  "products": [
-    "AI Builder",
-    "Power Platform",
-    "Power Automate",
-    "Dataverse"
-  ],
-  "tags": [
-    "CUSTOMER SUCCESS",
-    "CHURN",
-    "RETENTION",
-    "CHAIN-OF-THOUGHT",
-    "MULTI-SIGNAL",
-    "CRM"
-  ],
-  "categories": [
-    "AI Builder"
-  ],
-  "metadata": [
-    {
-      "key": "prompt",
-      "value": "Based on customer signals [last_login_date], [ticket_count], [ticket_sentiment], [renewal_date], [usage_trend], [nps_score], [account_tier] — assess churn risk and recommend 3 actions."
-    }
-  ],
-  "thumbnails": [],
-  "authors": [
-    {
-      "gitHubAccount": "OwnOptic",
-      "name": "OwnOptic",
-      "pictureUrl": "https://github.com/OwnOptic.png"
-    }
-  ],
-  "creationDateTime": "2026-03-02T00:00:00Z",
-  "updateDateTime": "2026-03-02T00:00:00Z"
-}
+[
+  {
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/pnp/samples/v1.0/metadata-schema.json",
+    "name": "pnp-powerplatform-prompts-customer-churn-risk-narrative",
+    "version": "1.0.0.0",
+    "source": "pnp",
+    "creationDateTime": "2026-03-02T00:00:00Z",
+    "updateDateTime": "2026-03-02T00:00:00Z",
+    "title": "Customer Churn Risk Narrative",
+    "shortDescription": "Converts six customer health signals into a plain-English churn risk narrative with risk level, explanation, and 3 urgency-ordered recommended actions for account managers.",
+    "longDescription": [
+      "Uses chain-of-thought reasoning and multi-signal synthesis to assess login recency, support ticket volume/sentiment, renewal proximity, usage trend, NPS, and account tier. Outputs a churn risk level (Critical/High/Medium/Low), a 2–3 sentence narrative explaining the risk, three concrete actions for the account manager ordered by urgency, and a per-signal status table. Designed for weekly Power Automate batch processing of Dataverse/Dynamics 365 accounts."
+    ],
+    "url": "https://github.com/pnp/powerplatform-prompts/tree/main/prompts/ai-builder/customer-churn-risk-narrative",
+    "products": [
+      "AI Builder",
+      "Power Platform",
+      "Power Automate",
+      "Dataverse"
+    ],
+    "tags": [
+      "CUSTOMER SUCCESS",
+      "CHURN",
+      "RETENTION",
+      "CHAIN-OF-THOUGHT",
+      "MULTI-SIGNAL",
+      "CRM"
+    ],
+    "categories": [
+      "AI Builder"
+    ],
+    "metadata": [
+      {
+        "key": "prompt",
+        "value": "Based on customer signals [last_login_date], [ticket_count], [ticket_sentiment], [renewal_date], [usage_trend], [nps_score], [account_tier] — assess churn risk and recommend 3 actions."
+      }
+    ],
+    "thumbnails": [
+      {
+        "type": "image",
+        "order": 100,
+        "url": "https://raw.githubusercontent.com/pnp/powerplatform-prompts/main/templates/previewprompts.png",
+        "alt": "Preview"
+      }
+    ],
+    "authors": [
+      {
+        "gitHubAccount": "OwnOptic",
+        "name": "OwnOptic",
+        "pictureUrl": "https://github.com/OwnOptic.png"
+      }
+    ]
+  }
+]

--- a/prompts/ai-builder/customer-churn-risk-narrative/en-us/prompt.md
+++ b/prompts/ai-builder/customer-churn-risk-narrative/en-us/prompt.md
@@ -1,0 +1,39 @@
+You are a customer success analyst. Based on the following customer signals, generate a clear churn risk narrative that a non-technical account manager can act on immediately.
+
+Customer signals provided:
+- Last login date: [last_login_date]
+- Support tickets opened in last 90 days: [ticket_count]
+- Last support ticket sentiment: [ticket_sentiment]
+- Contract renewal date: [renewal_date]
+- Product usage trend (last 3 months): [usage_trend]
+- NPS score (if available): [nps_score]
+- Account tier: [account_tier]
+
+Think step by step:
+Step 1 — Assess each signal individually: is it a warning sign, neutral, or positive indicator?
+Step 2 — Identify which signals carry the most weight for churn prediction.
+Step 3 — Determine the overall churn risk level: Critical / High / Medium / Low.
+Step 4 — Write a 2–3 sentence plain-English narrative explaining WHY this customer is at risk (or not).
+Step 5 — Recommend exactly 3 concrete actions the account manager should take this week, ordered by urgency.
+
+Format your output exactly as:
+
+## Churn Risk: [Critical | High | Medium | Low]
+
+## Why
+[2–3 sentence narrative]
+
+## Recommended Actions This Week
+1. [Action — be specific, include a suggested channel: call, email, in-app message]
+2. [Action]
+3. [Action]
+
+## Signal Summary
+| Signal | Status |
+|--------|--------|
+| Last Login | [Positive / Neutral / Warning] |
+| Support Tickets | [Positive / Neutral / Warning] |
+| Ticket Sentiment | [Positive / Neutral / Warning] |
+| Renewal Proximity | [Positive / Neutral / Warning] |
+| Usage Trend | [Positive / Neutral / Warning] |
+| NPS | [Positive / Neutral / Warning / N/A] |


### PR DESCRIPTION
## New sample: Customer Churn Risk Narrative

Adds an AI Builder prompt that converts six quantitative customer signals (login recency, support ticket volume and sentiment, renewal date, usage trend, NPS score, account tier) into a plain-English churn risk narrative with a risk level (Critical/High/Medium/Low), a 2-3 sentence explanation, and three concrete prioritized actions for the account manager.

### Scenario
Customer success teams running a weekly Power Automate flow over all active Dataverse accounts. Critical and High risk accounts trigger a Teams notification to the responsible account manager with the narrative and recommended actions.

### Benefits
- Chain-of-thought reasoning (five explicit internal steps before output)
- Multi-signal synthesis bridges the gap between raw metrics and human-readable action
- Output formatted for non-technical account managers, not data analysts